### PR TITLE
Allow returning the contentsList as an array

### DIFF
--- a/ParsedownToc.php
+++ b/ParsedownToc.php
@@ -178,7 +178,7 @@ class ParsedownToC extends DynamicParent
     /**
      * Returns the parsed ToC.
      *
-     * @param  string $type_return  Type of the return format. "html" or "json".
+     * @param  string $type_return  Type of the return format. "html", "json", or "array".
      * @return string               HTML/JSON string of ToC.
      */
     public function contentsList($type_return = 'html')
@@ -194,6 +194,10 @@ class ParsedownToC extends DynamicParent
 
         if ('json' === strtolower($type_return)) {
             return json_encode($this->contentsListArray);
+        }
+
+        if ('array' === strtolower($type_return)) {
+            return $this->contentsListArray;
         }
 
         // Forces to return ToC as "html"

--- a/ParsedownToc.php
+++ b/ParsedownToc.php
@@ -179,7 +179,7 @@ class ParsedownToC extends DynamicParent
      * Returns the parsed ToC.
      *
      * @param  string $type_return  Type of the return format. "html", "json", or "array".
-     * @return string               HTML/JSON string of ToC.
+     * @return string|array         HTML/JSON string, or array of ToC.
      */
     public function contentsList($type_return = 'html')
     {

--- a/README.md
+++ b/README.md
@@ -102,10 +102,10 @@ echo $body; // Main body
     - `body(string $text)`:
       - Returns the parsed content WITHOUT parsing `[toc]` tag.
     - `contentsList([string $type_return='html'])`:
-      - Returns the ToC, the table of contents, in HTML or JSON.
+      - Returns the ToC, the table of contents, in HTML, JSON or as an array.
       - **Optional argument:**
         - `$type_return`:
-          - `html` or `json` can be specified.
+          - `html`, `json`, or `array` can be specified.
           - **Default:** `html`
       - Alias method: `contentsList(string $type_return)`
     - `setTagToc(string $tag='[tag]')`:


### PR DESCRIPTION
I needed to interrogate the contents in PHP. (In my use case, I wanted the top-level heading for use as a page title.) The only way of currently doing this was to json_decode the json output, which seemed a bit wasteful.

This patch adds a new "array" return type which just returns the contentsListArray as is.