### PR TITLE
feat: option to prefix anchor with an URL

### DIFF
--- a/ParsedownToc.php
+++ b/ParsedownToc.php
@@ -39,6 +39,7 @@ class ParsedownToC extends DynamicParent
         'transliterate' => false,
         'urlencode' => false,
         'blacklist' => [],
+        'url' => '',
     );
 
     /**
@@ -465,7 +466,7 @@ class ParsedownToC extends DynamicParent
         $text  = $this->fetchText($Content['text']);
         $id    = $Content['id'];
         $level = (integer) trim($Content['level'], 'h');
-        $link  = "[${text}](#${id})";
+        $link  = "[${text}]({$this->options['url']}#${id})";
 
         if ($this->firstHeadLevel === 0) {
             $this->firstHeadLevel = $level;

--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ echo $body; // Main body
       - Use PHP build-in `urlencode` this will disable all other options
       - **Type:** `boolean`
       - **Default:** `false`
+
+    - `url`:
+
+      - Prefixes anchor with the specified URL
+      - **Type:** `string`
+      - **Default:** ``
+
   - **Methods:**
     - `text(string $text)`:
       - Returns the parsed content and `[toc]` tag(s) parsed as well.


### PR DESCRIPTION
The purpose of this feature is to generate the TOC of another page.

_Example:_

```php
$parsedown = new ParsedownToC(['selectors' => ['h2'], 'url' => $pageUrl]);
$parsedown->body($pageMarkdown);
$pageToc = $parsedown->contentsList();
```