### PR TITLE
fix: Using ${var} in strings is deprecated

### DIFF
--- a/ParsedownToc.php
+++ b/ParsedownToc.php
@@ -466,7 +466,7 @@ class ParsedownToC extends DynamicParent
         $text  = $this->fetchText($Content['text']);
         $id    = $Content['id'];
         $level = (integer) trim($Content['level'], 'h');
-        $link  = "[${text}]({$this->options['url']}#${id})";
+        $link  = "[{$text}]({$this->options['url']}#{$id})";
 
         if ($this->firstHeadLevel === 0) {
             $this->firstHeadLevel = $level;
@@ -486,7 +486,7 @@ class ParsedownToC extends DynamicParent
         //     - [Header3](#Header3)
         //   - [Header2-2](#Header2-2)
         // ...
-        $this->contentsListString .= "${indent}- ${link}" . PHP_EOL;
+        $this->contentsListString .= "{$indent}- {$link}" . PHP_EOL;
     }
     protected $contentsListString = '';
     protected $firstHeadLevel = 0;
@@ -537,7 +537,7 @@ class ParsedownToC extends DynamicParent
         $toc_data = $this->contentsList();
         $toc_id   = $this->getIdAttributeToC();
         $needle  = '<p>' . $tag_origin . '</p>';
-        $replace = "<div id=\"${toc_id}\">${toc_data}</div>";
+        $replace = "<div id=\"{$toc_id}\">{$toc_data}</div>";
 
         return str_replace($needle, $replace, $html);
     }


### PR DESCRIPTION
Use {$var} instead in newer PHP.

Since PHP 8.x this is creating verbose warnings, so it's better to migrate away from the deprecated `${var}` notation