### PR TITLE
Fix deprecated usages of ${foo} in strings

### DIFF
--- a/ParsedownToc.php
+++ b/ParsedownToc.php
@@ -466,7 +466,7 @@ class ParsedownToC extends DynamicParent
         $text  = $this->fetchText($Content['text']);
         $id    = $Content['id'];
         $level = (integer) trim($Content['level'], 'h');
-        $link  = "[${text}]({$this->options['url']}#${id})";
+        $link  = "[{$text}]({$this->options['url']}#{$id})";
 
         if ($this->firstHeadLevel === 0) {
             $this->firstHeadLevel = $level;
@@ -486,7 +486,7 @@ class ParsedownToC extends DynamicParent
         //     - [Header3](#Header3)
         //   - [Header2-2](#Header2-2)
         // ...
-        $this->contentsListString .= "${indent}- ${link}" . PHP_EOL;
+        $this->contentsListString .= "{$indent}- {$link}" . PHP_EOL;
     }
     protected $contentsListString = '';
     protected $firstHeadLevel = 0;
@@ -537,7 +537,7 @@ class ParsedownToC extends DynamicParent
         $toc_data = $this->contentsList();
         $toc_id   = $this->getIdAttributeToC();
         $needle  = '<p>' . $tag_origin . '</p>';
-        $replace = "<div id=\"${toc_id}\">${toc_data}</div>";
+        $replace = "<div id=\"{$toc_id}\">{$toc_data}</div>";
 
         return str_replace($needle, $replace, $html);
     }


### PR DESCRIPTION
This fixes deprecation warnings in PHP 8.2.1.

Example warning: Deprecated: Using ${var} in strings is deprecated, use {$var} instead in /vendor/benjaminhoegh/parsedown-toc/ParsedownToc.php on line 469