### PR TITLE
fix: Declaration of a missed property

### DIFF
--- a/ParsedownToc.php
+++ b/ParsedownToc.php
@@ -41,6 +41,7 @@ class ParsedownToC extends DynamicParent
         'blacklist' => [],
         'url' => '',
     );
+    protected $options = array();
 
     /**
      * Version requirement check.


### PR DESCRIPTION
so that it is not considered to be dynamic by PHP 8.2