### PR TITLE
Explicitly declare $options as ParsedownToC member variable

### DIFF
--- a/ParsedownToc.php
+++ b/ParsedownToc.php
@@ -42,6 +42,8 @@ class ParsedownToC extends DynamicParent
         'url' => '',
     );
 
+    protected $options;
+
     /**
      * Version requirement check.
      */


### PR DESCRIPTION
To prevent warning in newer PHP 8.x

Deprecated: Creation of dynamic property ParsedownToC::$options is deprecated