### PR TITLE
fix URL option

### DIFF
--- a/src/ParsedownToc.php
+++ b/src/ParsedownToc.php
@@ -678,7 +678,7 @@ class ParsedownToc extends ParsedownTocParentAlias
         $text = $this->fetchText($Content['text']);
         $id = $Content['id'];
         $level = (int) trim($Content['level'], 'h');
-        $link = "[{$text}](#{$id})";
+        $link = "[{$text}]({$this->options['url']}#{$id})";
 
         if ($this->firstHeadLevel === 0) {
             $this->firstHeadLevel = $level;


### PR DESCRIPTION
It seams the URL option have been lost during the changes from ParsedownToc 1.4.x to 1.5.x:

```php
$link  = "[{$text}]({$this->options['url']}#{$id})";
```
https://github.com/BenjaminHoegh/ParsedownToc/blob/1.4.3/ParsedownToc.php#L469

This little patch apply to fix that.