### PR TITLE
Refactor attribute assignment for heading IDs

### DIFF
--- a/src/ParsedownToc.php
+++ b/src/ParsedownToc.php
@@ -243,13 +243,12 @@ class ParsedownToc extends ParsedownTocParentAlias
             $level = $Block['element']['name'];
             $id = $Block['element']['attributes']['id'] ?? $this->createAnchorID($text);
 
-            $Block['element']['attributes'] = ['id' => $id];
-
             // Check if heading level is in the selectors
             if (!in_array($level, $this->options['selectors'])) {
                 return $Block;
             }
-
+            
+            $Block['element']['attributes'] = ['id' => $id];
             $this->setContentsList(['text' => $text, 'id' => $id, 'level' => $level]);
 
             return $Block;


### PR DESCRIPTION
This pull request makes a small adjustment to the placement of the code that sets the `id` attribute on heading elements in the `blockHeader` method. The assignment is moved to occur only after confirming the heading level is included in the selectors, ensuring that IDs are only added to relevant headings.