### PR TITLE
2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,36 +146,17 @@ $toc  = $parser->getContentsList();
 
 ## Configuration
 
-Options can be set in bulk with `setOptions()` or individually via dedicated setters. Both approaches are interchangeable and can be mixed freely.
-
-### Bulk configuration
+All setters return `static`, so they can be chained freely.
 
 ```php
-$parser = new ParsedownToc();
-
-$parser->setOptions([
-    'heading_levels'  => ['h2', 'h3'],
-    'delimiter'       => '_',
-    'toc_items_limit' => 10,
-    'lowercase'       => true,
-    'prefix'          => 'heading-',
-    'reserved_ids'    => ['toc', 'introduction'],
-    'toc_tag'         => '[toc]',
-    'toc_id'          => 'toc',
-]);
-```
-
-### Individual setters
-
-```php
-$parser->setHeadingLevels(['h2', 'h3']);
-$parser->setDelimiter('_');
-$parser->setTocItemsLimit(10);
-$parser->setLowercase(true);
-$parser->setTocPrefix('heading-');
-$parser->setReservedIds(['toc', 'introduction']);
-$parser->setTocTag('[toc]');
-$parser->setTocId('toc');
+$parser = (new ParsedownToc())
+    ->setHeadingLevels(['h2', 'h3'])
+    ->setDelimiter('_')
+    ->setLowercase(true)
+    ->setPrefix('heading-')
+    ->setReservedIds(['toc', 'introduction'])
+    ->setTocTag('[toc]')
+    ->setTocId('toc');
 ```
 
 ### Available options
@@ -184,7 +165,6 @@ $parser->setTocId('toc');
 |---|---|---|---|
 | `heading_levels` | `string[]` | `['h1'…'h6']` | Which heading levels to include in the ToC |
 | `delimiter` | `string` | `'-'` | Character used to replace spaces and non-alphanumeric characters in anchor IDs |
-| `toc_items_limit` | `int\|null` | `null` | Maximum number of headings to include in the ToC; `null` means unlimited |
 | `lowercase` | `bool` | `true` | Convert anchor IDs to lowercase |
 | `replacements` | `array<string,string>\|null` | `null` | Map of strings or regex patterns to replace in the slug before sanitization |
 | `transliterate` | `bool` | `false` | Transliterate non-ASCII characters to their ASCII equivalents before slugging |
@@ -231,18 +211,15 @@ $parser->setReplacements([
 
 | Method | Description |
 |---|---|
-| `setOptions(array $options)` | Set multiple options at once |
-| `getOptions()` | Return the current options array |
 | `getTocTag()` | Return the current ToC marker string |
 | `setHeadingLevels(array $levels)` | Set which heading levels to include |
 | `setDelimiter(string $delimiter)` | Set the slug delimiter character |
-| `setTocItemsLimit(?int $limit)` | Set the maximum number of ToC entries |
 | `setLowercase(bool $lowercase)` | Enable or disable lowercasing of anchor IDs |
 | `setReplacements(?array $replacements)` | Set string/regex replacements for slug generation |
 | `setTransliterate(bool $transliterate)` | Enable or disable transliteration |
 | `setUrlencode(bool $urlencode)` | Enable or disable URL encoding of anchor IDs |
 | `setReservedIds(array $ids)` | Set anchor IDs that must not be generated |
-| `setTocPrefix(string $prefix)` | Set a prefix for all generated anchor IDs |
+| `setPrefix(string $prefix)` | Set a prefix for all generated anchor IDs |
 | `setTocTag(string $tag)` | Set the Markdown marker to replace with the ToC |
 | `setTocId(string $id)` | Set the `id` attribute of the ToC wrapper element |
 | `setAnchorIdGenerator(callable $generator)` | Provide a custom anchor ID generation callable |

--- a/src/ParsedownToc.php
+++ b/src/ParsedownToc.php
@@ -19,25 +19,30 @@ class ParsedownToc extends ParsedownTocParentAlias
     public const VERSION_PARSEDOWN_EXTRA_REQUIRED = '0.9.0';
     public const MIN_PHP_VERSION = '8.2';
 
-    /** @var array<string, mixed> */
-    private const DEFAULT_OPTIONS = [
-        'heading_levels' => ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'],
-        'delimiter' => '-',
-        'toc_items_limit' => null,
-        'lowercase' => true,
-        'replacements' => null,
-        'transliterate' => false,
-        'urlencode' => false,
-        'reserved_ids' => [],
-        'prefix' => '',
-        'toc_tag' => '[toc]',
-        'toc_id' => 'toc',
-    ];
-
     private const ALLOWED_HEADING_LEVELS = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
 
-    /** @var array<string, mixed> */
-    protected array $options = self::DEFAULT_OPTIONS;
+    /** @var list<string> */
+    private array $headingLevels = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'];
+
+    private string $delimiter = '-';
+
+    private bool $lowercase = true;
+
+    /** @var array<string, string>|null */
+    private ?array $replacements = null;
+
+    private bool $transliterate = false;
+
+    private bool $urlencode = false;
+
+    /** @var list<string> */
+    private array $reservedIds = [];
+
+    private string $prefix = '';
+
+    private string $tocTag = '[toc]';
+
+    private string $tocId = 'toc';
 
     /** @var array<string, int> */
     private array $anchorDuplicates = [];
@@ -62,32 +67,9 @@ class ParsedownToc extends ParsedownTocParentAlias
     }
 
     /**
-     * @param array<string, mixed> $options
-     */
-    public function setOptions(array $options): void
-    {
-        foreach ($options as $name => $value) {
-            match ($name) {
-                'heading_levels' => $this->setHeadingLevels($this->assertStringList($value, $name)),
-                'delimiter' => $this->setDelimiter($this->assertString($value, $name)),
-                'toc_items_limit' => $this->setTocItemsLimit($this->assertNullableNonNegativeInt($value, $name)),
-                'lowercase' => $this->setLowercase($this->assertBool($value, $name)),
-                'replacements' => $this->setReplacements($this->assertNullableStringMap($value, $name)),
-                'transliterate' => $this->setTransliterate($this->assertBool($value, $name)),
-                'urlencode' => $this->setUrlencode($this->assertBool($value, $name)),
-                'reserved_ids' => $this->setReservedIds($this->assertStringList($value, $name)),
-                'prefix' => $this->setTocPrefix($this->assertString($value, $name)),
-                'toc_tag' => $this->setTocTag($this->assertString($value, $name)),
-                'toc_id' => $this->setTocId($this->assertString($value, $name)),
-                default => throw new \InvalidArgumentException(sprintf('Unknown option "%s".', $name)),
-            };
-        }
-    }
-
-    /**
      * @param list<string> $headingLevels
      */
-    public function setHeadingLevels(array $headingLevels): void
+    public function setHeadingLevels(array $headingLevels): static
     {
         foreach ($headingLevels as $level) {
             if (!in_array($level, self::ALLOWED_HEADING_LEVELS, true)) {
@@ -95,87 +77,90 @@ class ParsedownToc extends ParsedownTocParentAlias
             }
         }
 
-        $this->options['heading_levels'] = $headingLevels;
+        $this->headingLevels = array_values($headingLevels);
+
+        return $this;
     }
 
-    public function setDelimiter(string $slugDelimiter): void
+    public function setDelimiter(string $delimiter): static
     {
-        if ($slugDelimiter === '') {
+        if ($delimiter === '') {
             throw new \InvalidArgumentException('Slug delimiter cannot be empty.');
         }
 
-        $this->options['delimiter'] = $slugDelimiter;
+        $this->delimiter = $delimiter;
+
+        return $this;
     }
 
-    public function setTocItemsLimit(?int $tocItemsLimit): void
+    public function setLowercase(bool $lowercase): static
     {
-        if ($tocItemsLimit !== null && $tocItemsLimit < 0) {
-            throw new \InvalidArgumentException('TOC item limit must be null or a non-negative integer.');
-        }
+        $this->lowercase = $lowercase;
 
-        $this->options['toc_items_limit'] = $tocItemsLimit;
-    }
-
-    public function setLowercase(bool $slugLowercase): void
-    {
-        $this->options['lowercase'] = $slugLowercase;
+        return $this;
     }
 
     /**
-     * @param array<string, string>|null $slugReplacements
+     * @param array<string, string>|null $replacements
      */
-    public function setReplacements(?array $slugReplacements): void
+    public function setReplacements(?array $replacements): static
     {
-        $this->options['replacements'] = $slugReplacements;
+        $this->replacements = $replacements;
+
+        return $this;
     }
 
-    public function setTransliterate(bool $slugTransliterate): void
+    public function setTransliterate(bool $transliterate): static
     {
-        $this->options['transliterate'] = $slugTransliterate;
+        $this->transliterate = $transliterate;
+
+        return $this;
     }
 
-    public function setUrlencode(bool $slugUrlencode): void
+    public function setUrlencode(bool $urlencode): static
     {
-        $this->options['urlencode'] = $slugUrlencode;
+        $this->urlencode = $urlencode;
+
+        return $this;
     }
 
     /**
      * @param list<string> $reservedIds
      */
-    public function setReservedIds(array $reservedIds): void
+    public function setReservedIds(array $reservedIds): static
     {
-        $this->options['reserved_ids'] = $reservedIds;
+        $this->reservedIds = array_values($reservedIds);
+
+        return $this;
     }
 
-    public function setTocPrefix(string $prefix): void
+    public function setPrefix(string $prefix): static
     {
-        $this->options['prefix'] = $prefix;
+        $this->prefix = $prefix;
+
+        return $this;
     }
 
-    public function setTocTag(string $tocTag): void
+    public function setTocTag(string $tocTag): static
     {
         if ($tocTag === '') {
             throw new \InvalidArgumentException('TOC tag cannot be empty.');
         }
 
-        $this->options['toc_tag'] = $tocTag;
+        $this->tocTag = $tocTag;
+
+        return $this;
     }
 
-    public function setTocId(string $tocId): void
+    public function setTocId(string $tocId): static
     {
         if ($tocId === '') {
             throw new \InvalidArgumentException('TOC ID cannot be empty.');
         }
 
-        $this->options['toc_id'] = $tocId;
-    }
+        $this->tocId = $tocId;
 
-    /**
-     * @return array<string, mixed>
-     */
-    public function getOptions(): array
-    {
-        return $this->options;
+        return $this;
     }
 
     /**
@@ -239,9 +224,11 @@ class ParsedownToc extends ParsedownTocParentAlias
      *
      * @param callable(string, array<string, mixed>): string $anchorIdGenerator
      */
-    public function setAnchorIdGenerator(callable $anchorIdGenerator): void
+    public function setAnchorIdGenerator(callable $anchorIdGenerator): static
     {
         $this->anchorIdGenerator = $anchorIdGenerator;
+
+        return $this;
     }
 
     /**
@@ -292,7 +279,7 @@ class ParsedownToc extends ParsedownTocParentAlias
 
         $level = $element['name'] ?? null;
 
-        if (!is_string($level) || !in_array($level, $this->options['heading_levels'], true)) {
+        if (!is_string($level) || !in_array($level, $this->headingLevels, true)) {
             return $block;
         }
 
@@ -421,30 +408,30 @@ class ParsedownToc extends ParsedownTocParentAlias
     private function createAnchorID(string $text): string
     {
         if ($this->anchorIdGenerator !== null) {
-            return (string) call_user_func($this->anchorIdGenerator, $text, $this->options);
+            return (string) call_user_func($this->anchorIdGenerator, $text, $this->buildOptionsSnapshot());
         }
 
         $text = $this->normalizeString($text);
 
-        if ($this->options['lowercase'] === true) {
+        if ($this->lowercase === true) {
             $text = mb_strtolower($text, 'UTF-8');
         }
 
-        if (is_array($this->options['replacements'])) {
-            $text = $this->applyReplacements($text, $this->options['replacements']);
+        if (is_array($this->replacements)) {
+            $text = $this->applyReplacements($text, $this->replacements);
         }
 
-        if ($this->options['transliterate'] === true) {
+        if ($this->transliterate === true) {
             $text = $this->transliterateWithCharacterMap($text);
 
-            if ($this->options['lowercase'] === true) {
+            if ($this->lowercase === true) {
                 $text = strtolower($text);
             }
         }
 
         $text = $this->sanitizeAnchor($text);
 
-        if ($this->options['urlencode'] === true) {
+        if ($this->urlencode === true) {
             $text = rawurlencode($text);
         }
 
@@ -601,13 +588,13 @@ class ParsedownToc extends ParsedownTocParentAlias
 
     private function sanitizeAnchor(string $text): string
     {
-        $delimiter = (string) $this->options['delimiter'];
+        $delimiter = $this->delimiter;
 
         if ($delimiter === '') {
             throw new \RuntimeException('Slug delimiter cannot be empty.');
         }
 
-        $pattern = $this->options['transliterate'] === true
+        $pattern = $this->transliterate === true
             ? '/[^A-Za-z0-9]+/'
             : '/[^\p{L}\p{Nd}]+/u';
 
@@ -619,7 +606,7 @@ class ParsedownToc extends ParsedownTocParentAlias
 
     private function applyAnchorPrefix(string $text): string
     {
-        $prefix = (string) $this->options['prefix'];
+        $prefix = $this->prefix;
 
         if ($prefix === '') {
             return $text;
@@ -630,8 +617,7 @@ class ParsedownToc extends ParsedownTocParentAlias
 
     private function uniquifyAnchorID(string $text): string
     {
-        /** @var list<string> $reservedIds */
-        $reservedIds = $this->options['reserved_ids'];
+        $reservedIds = $this->reservedIds;
 
         $this->anchorDuplicates[$text] ??= 0;
 
@@ -704,7 +690,7 @@ class ParsedownToc extends ParsedownTocParentAlias
 
     private function getTocIdAttribute(): string
     {
-        return (string) $this->options['toc_id'];
+        return $this->tocId;
     }
 
     private function getSalt(): string
@@ -714,7 +700,7 @@ class ParsedownToc extends ParsedownTocParentAlias
 
     public function getTocTag(): string
     {
-        return (string) $this->options['toc_tag'];
+        return $this->tocTag;
     }
 
     /**
@@ -722,12 +708,6 @@ class ParsedownToc extends ParsedownTocParentAlias
      */
     private function setContentsList(array $content): void
     {
-        $limit = $this->options['toc_items_limit'];
-
-        if ($limit !== null && count($this->contentsListArray) >= $limit) {
-            return;
-        }
-
         $this->contentsListArray[] = $content;
     }
 
@@ -766,6 +746,25 @@ class ParsedownToc extends ParsedownTocParentAlias
         }
 
         return $result;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildOptionsSnapshot(): array
+    {
+        return [
+            'heading_levels' => $this->headingLevels,
+            'delimiter'      => $this->delimiter,
+            'lowercase'      => $this->lowercase,
+            'replacements'   => $this->replacements,
+            'transliterate'  => $this->transliterate,
+            'urlencode'      => $this->urlencode,
+            'reserved_ids'   => $this->reservedIds,
+            'prefix'         => $this->prefix,
+            'toc_tag'        => $this->tocTag,
+            'toc_id'         => $this->tocId,
+        ];
     }
 
     private function assertRuntimeRequirements(): void
@@ -810,82 +809,4 @@ class ParsedownToc extends ParsedownTocParentAlias
         $constructor->invoke($this);
     }
 
-    /**
-     * @return list<string>
-     */
-    private function assertStringList(mixed $value, string $optionName): array
-    {
-        if (!is_array($value)) {
-            throw new \InvalidArgumentException(sprintf('Option "%s" must be an array of strings.', $optionName));
-        }
-
-        foreach ($value as $item) {
-            if (!is_string($item)) {
-                throw new \InvalidArgumentException(sprintf('Option "%s" must contain strings only.', $optionName));
-            }
-        }
-
-        return array_values($value);
-    }
-
-    private function assertString(mixed $value, string $optionName): string
-    {
-        if (!is_string($value)) {
-            throw new \InvalidArgumentException(sprintf('Option "%s" must be a string.', $optionName));
-        }
-
-        return $value;
-    }
-
-    private function assertBool(mixed $value, string $optionName): bool
-    {
-        if (!is_bool($value)) {
-            throw new \InvalidArgumentException(sprintf('Option "%s" must be a boolean.', $optionName));
-        }
-
-        return $value;
-    }
-
-    private function assertNullableNonNegativeInt(mixed $value, string $optionName): ?int
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        if (!is_int($value) || $value < 0) {
-            throw new \InvalidArgumentException(
-                sprintf('Option "%s" must be null or a non-negative integer.', $optionName)
-            );
-        }
-
-        return $value;
-    }
-
-    /**
-     * @return array<string, string>|null
-     */
-    private function assertNullableStringMap(mixed $value, string $optionName): ?array
-    {
-        if ($value === null) {
-            return null;
-        }
-
-        if (!is_array($value)) {
-            throw new \InvalidArgumentException(sprintf('Option "%s" must be null or an array.', $optionName));
-        }
-
-        $result = [];
-
-        foreach ($value as $search => $replacement) {
-            if (!is_string($search) || !is_scalar($replacement)) {
-                throw new \InvalidArgumentException(
-                    sprintf('Option "%s" must be an array<string, scalar>.', $optionName)
-                );
-            }
-
-            $result[$search] = (string) $replacement;
-        }
-
-        return $result;
-    }
 }

--- a/tests/AnchorIDGenerationTest.php
+++ b/tests/AnchorIDGenerationTest.php
@@ -29,7 +29,7 @@ class AnchorIDGenerationTest extends TestCase
     public function testAnchorIDDuplicate()
     {
         $text = "heading";
-        $this->parsedownToc->setOptions(['reserved_ids' => []]); // Ensure no reserved id interference
+        $this->parsedownToc->setReservedIds([]); // Ensure no reserved id interference
 
         $firstCall = $this->invokeMethod($this->parsedownToc, 'createAnchorID', [$text]);
         $secondCall = $this->invokeMethod($this->parsedownToc, 'createAnchorID', [$text]);
@@ -46,12 +46,12 @@ class AnchorIDGenerationTest extends TestCase
      * This test verifies that the custom anchor ID generation callback is correctly set and applied.
      * It checks if the generated HTML contains the expected anchor ID based on the custom function.
      */
-    public function testAnchorIDCustomCallback()
+    public function testAnchorIdGenerator()
     {
         $customFunction = function ($text, $options) {
             return mb_strtolower(str_replace(' ', '_', $text));
         };
-        $this->parsedownToc->setCreateAnchorIDCallback($customFunction);
+        $this->parsedownToc->setAnchorIdGenerator($customFunction);
 
         $markdown = "# custom heading";
         $html = $this->parsedownToc->text($markdown);
@@ -69,7 +69,7 @@ class AnchorIDGenerationTest extends TestCase
     public function testAnchorIDReservedIds()
     {
         $text = "heading";
-        $this->parsedownToc->setOptions(['reserved_ids' => ['heading']]);
+        $this->parsedownToc->setReservedIds(['heading']);
 
         $result = $this->invokeMethod($this->parsedownToc, 'createAnchorID', [$text]);
         $this->assertNotEquals('heading', $result);
@@ -90,7 +90,7 @@ class AnchorIDGenerationTest extends TestCase
      */
     public function testAnchorIDHeadingLevels()
     {
-        $this->parsedownToc->setOptions(['heading_levels' => ['h1']]);
+        $this->parsedownToc->setHeadingLevels(['h1']);
 
         $text = "# heading1";
         $this->parsedownToc->text($text);
@@ -108,7 +108,7 @@ class AnchorIDGenerationTest extends TestCase
      */
     public function testExcludedATXHeadingDoesNotConsumeGeneratedID()
     {
-        $this->parsedownToc->setOptions(['heading_levels' => ['h2']]);
+        $this->parsedownToc->setHeadingLevels(['h2']);
 
         $excludedHtml = $this->parsedownToc->text("# heading");
         $includedHtml = $this->parsedownToc->text("## heading");
@@ -123,7 +123,7 @@ class AnchorIDGenerationTest extends TestCase
      */
     public function testExcludedSetextHeadingDoesNotConsumeGeneratedID()
     {
-        $this->parsedownToc->setOptions(['heading_levels' => ['h2']]);
+        $this->parsedownToc->setHeadingLevels(['h2']);
 
         $excludedHtml = $this->parsedownToc->text("heading\n===");
         $includedHtml = $this->parsedownToc->text("heading\n---");
@@ -156,7 +156,7 @@ class AnchorIDGenerationTest extends TestCase
      */
     public function testAnchorIDSanitizeAnchorCustomDelimiter()
     {
-        $this->parsedownToc->setOptions(['delimiter' => '&']);
+        $this->parsedownToc->setDelimiter('&');
 
         $text = "heading with spaces";
         $result = $this->invokeMethod($this->parsedownToc, 'sanitizeAnchor', [$text]);
@@ -174,7 +174,7 @@ class AnchorIDGenerationTest extends TestCase
 
     public function testAnchorIDRespectsPrefixOption()
     {
-        $this->parsedownToc->setTocPrefix('md-');
+        $this->parsedownToc->setPrefix('md-');
 
         $html = $this->parsedownToc->text('# Heading');
 

--- a/tests/ContentListManagementTest.php
+++ b/tests/ContentListManagementTest.php
@@ -73,26 +73,13 @@ class ContentListManagementTest extends TestCase
 
     public function testContentsListRespectsHeadingIdPrefix()
     {
-        $this->parsedownToc->setTocPrefix('md-');
+        $this->parsedownToc->setPrefix('md-');
 
         $html = $this->parsedownToc->text("# Heading 1");
         $result = $this->parsedownToc->getContentsList();
 
         $this->assertStringContainsString('<h1 id="md-heading-1">Heading 1</h1>', $html);
         $this->assertStringContainsString('<a href="#md-heading-1">Heading 1</a>', $result);
-    }
-
-    public function testContentsListRespectsLimit()
-    {
-        $this->parsedownToc->setTocItemsLimit(1);
-
-        $html = $this->parsedownToc->text("# First\n\n# Second\n\n[toc]");
-        $result = $this->parsedownToc->getContentsList();
-
-        $this->assertStringContainsString('<h1 id="first">First</h1>', $html);
-        $this->assertStringContainsString('<h1 id="second">Second</h1>', $html);
-        $this->assertStringContainsString('<a href="#first">First</a>', $result);
-        $this->assertStringNotContainsString('<a href="#second">Second</a>', $result);
     }
 
     public function testContentsListInvalidType()

--- a/tests/SettersTest.php
+++ b/tests/SettersTest.php
@@ -4,7 +4,7 @@ use PHPUnit\Framework\TestCase;
 
 class SettersTest extends TestCase
 {
-    protected $parsedownToc;
+    protected ParsedownToc $parsedownToc;
 
     protected function setUp(): void
     {
@@ -12,140 +12,167 @@ class SettersTest extends TestCase
         $this->parsedownToc->setSafeMode(true);
     }
 
-    /**
-     * Test case for the `setOptions` method.
-     */
-    public function testSetOptions()
-    {
-        $options = [
-            'toc_id' => '[[toc]]',
-        ];
+    // -------------------------------------------------------------------------
+    // Behavioral setter tests
+    // -------------------------------------------------------------------------
 
-        $this->parsedownToc->setOptions($options);
-        $this->assertEquals($options['toc_id'], $this->parsedownToc->getOptions()['toc_id']);
+    public function testSetHeadingLevels(): void
+    {
+        $this->parsedownToc->setHeadingLevels(['h1', 'h2', 'h3', 'h4']);
+
+        $this->parsedownToc->text("# H1\n\n##### H5");
+        $list = $this->parsedownToc->getContentsList('array');
+
+        $levels = array_column($list, 'level');
+        $this->assertContains('h1', $levels);
+        $this->assertNotContains('h5', $levels);
     }
 
-    /**
-     * Test case for the `setHeadingLevels` method.
-     */
-    public function testSetHeadingLevels()
+    public function testSetDelimiter(): void
     {
-        $headingLevels = [
-            'h1' => 'h1',
-            'h2' => 'h2',
-            'h3' => 'h3',
-            'h4' => 'h4',
-        ];
+        $this->parsedownToc->setDelimiter('_');
 
-        $this->parsedownToc->setHeadingLevels($headingLevels);
-        $this->assertEquals($headingLevels, $this->parsedownToc->getOptions()['heading_levels']);
+        $output = $this->parsedownToc->text('# Hello World');
+
+        $this->assertStringContainsString('id="hello_world"', $output);
     }
 
-    /**
-     * Test case for the `setDelimiter` method.
-     */
-    public function testsetDelimiter()
+    public function testSetLowercase(): void
     {
-        $delimiter = '&';
+        $this->parsedownToc->setLowercase(false);
 
-        $this->parsedownToc->setDelimiter($delimiter);
-        $this->assertEquals($delimiter, $this->parsedownToc->getOptions()['delimiter']);
+        $output = $this->parsedownToc->text('# Hello World');
+
+        $this->assertStringContainsString('id="Hello-World"', $output);
     }
 
-    /**
-     * Test case for the `setTocItemsLimit` method.
-     */
-    public function testSetTocItemsLimit()
+    public function testSetReplacements(): void
     {
-        $limit = 3;
+        $this->parsedownToc->setReplacements(['o' => '0']);
 
-        $this->parsedownToc->setTocItemsLimit($limit);
-        $this->assertEquals($limit, $this->parsedownToc->getOptions()['toc_items_limit']);
+        $output = $this->parsedownToc->text('# Hello World');
+
+        $this->assertStringContainsString('id="hell0-w0rld"', $output);
     }
 
-    /**
-     * Test case for the `setLowercase` method.
-     */
-    public function testsetLowercase()
+    public function testSetTransliterate(): void
     {
-        $lowercase = false;
+        $this->parsedownToc->setTransliterate(true);
 
-        $this->parsedownToc->setLowercase($lowercase);
-        $this->assertEquals($lowercase, $this->parsedownToc->getOptions()['lowercase']);
+        $output = $this->parsedownToc->text('# Héllo');
+
+        $this->assertStringContainsString('id="hello"', $output);
     }
 
-    /**
-     * Test case for the `setReplacements` method.
-     */
-    public function testsetReplacements()
+    public function testSetUrlencode(): void
     {
-        $replacements = [
-            'BadKitty' => '-',
-        ];
+        $this->parsedownToc->setLowercase(false)->setUrlencode(true);
 
-        $this->parsedownToc->setReplacements($replacements);
-        $this->assertEquals($replacements, $this->parsedownToc->getOptions()['replacements']);
+        $output = $this->parsedownToc->text('# Héllo');
+
+        $this->assertStringContainsString('id="H%C3%A9llo"', $output);
     }
 
-    /**
-     * Test case for the `setTransliterate` method.
-     */
-    public function testsetTransliterate()
+    public function testSetReservedIds(): void
     {
-        $transliterate = false;
+        $this->parsedownToc->setReservedIds(['test']);
 
-        $this->parsedownToc->setTransliterate($transliterate);
-        $this->assertEquals($transliterate, $this->parsedownToc->getOptions()['transliterate']);
+        $output = $this->parsedownToc->text('# Test');
+
+        $this->assertStringContainsString('id="test-1"', $output);
     }
 
-    /**
-     * Test case for the `setUrlencode` method.
-     */
-    public function testsetUrlencode()
+    public function testSetPrefix(): void
     {
-        $urlencode = false;
+        $this->parsedownToc->setPrefix('/docs/');
 
-        $this->parsedownToc->setUrlencode($urlencode);
-        $this->assertEquals($urlencode, $this->parsedownToc->getOptions()['urlencode']);
+        $output = $this->parsedownToc->text('# Page');
+
+        $this->assertStringContainsString('id="/docs/page"', $output);
     }
 
-    /**
-     * Test case for the `setReservedIds` method.
-     */
-    public function testSetReservedIds()
+    public function testSetTocTag(): void
     {
-        $reservedIds = [
-            'myBlacklistedHeaderId',
-        ];
+        $this->parsedownToc->setTocTag('[nav]');
 
-        $this->parsedownToc->setReservedIds($reservedIds);
-        $this->assertEquals($reservedIds, $this->parsedownToc->getOptions()['reserved_ids']);
+        $output = $this->parsedownToc->text("# Heading\n\n[nav]");
+
+        $this->assertStringContainsString('<div id="toc">', $output);
+        $this->assertStringNotContainsString('<p>[nav]</p>', $output);
     }
 
-    /**
-     * Test case for the `setTocPrefix` method.
-     */
-    public function testSetTocPrefix()
+    public function testSetTocId(): void
     {
-        $prefix = '/docs/page';
+        $this->parsedownToc->setTocId('my-toc');
 
-        $this->parsedownToc->setTocPrefix($prefix);
-        $this->assertEquals($prefix, $this->parsedownToc->getOptions()['prefix']);
+        $output = $this->parsedownToc->text("# Heading\n\n[toc]");
+
+        $this->assertStringContainsString('<div id="my-toc">', $output);
     }
 
-    /**
-     * Test case for the `setTocTag` method.
-     */
-    public function testSetTocTag()
+    public function testSetReplacementsAcceptsNull(): void
     {
-        $tag = 'nav';
+        $this->parsedownToc->setReplacements(null);
 
-        $this->parsedownToc->setTocTag($tag);
-        $this->assertEquals($tag, $this->parsedownToc->getOptions()['toc_tag']);
+        $output = $this->parsedownToc->text('# Test');
+
+        $this->assertStringContainsString('id="test"', $output);
     }
+
+    // -------------------------------------------------------------------------
+    // Fluent chaining
+    // -------------------------------------------------------------------------
+
+    public function testFluentChainingReturnsSelf(): void
+    {
+        $result = $this->parsedownToc->setDelimiter('_');
+
+        $this->assertInstanceOf(ParsedownToc::class, $result);
+    }
+
+    public function testFluentChainingAppliesAllSettings(): void
+    {
+        $output = $this->parsedownToc
+            ->setDelimiter('_')
+            ->setLowercase(false)
+            ->text('# Hello World');
+
+        $this->assertStringContainsString('id="Hello_World"', $output);
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation / guard-clause tests
+    // -------------------------------------------------------------------------
+
+    public function testSetHeadingLevelsThrowsOnInvalidLevel(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->parsedownToc->setHeadingLevels(['h7']);
+    }
+
+    public function testSetDelimiterThrowsOnEmptyString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->parsedownToc->setDelimiter('');
+    }
+
+    public function testSetTocTagThrowsOnEmptyString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->parsedownToc->setTocTag('');
+    }
+
+    public function testSetTocIdThrowsOnEmptyString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->parsedownToc->setTocId('');
+    }
+
+    // -------------------------------------------------------------------------
 
     protected function tearDown(): void
     {
         unset($this->parsedownToc);
     }
 }
+


### PR DESCRIPTION

### Added
- Fluent API for settings
- Unicode normalization via `Normalizer` (when available)
- Stronger type declarations and stricter internal state handling

### Changed
- Minimum PHP version increased from **7.4** to **8.2**.
- Minimum Parsedown version increased from **1.7.4** to **1.8.0**.
- Minimum ParsedownExtra version increased from **0.8.1** to **0.9.0**.
- `contentsList()` → `getContentsList()`
- `setCreateAnchorIDCallback()` → `setAnchorIdGenerator()`
- Removed `setOptions()` / `getOptions()`
- Renamed options & setters:
    - `selectors` → `setHeadingLevels()`
    - `blacklist` → `setReservedIds()`
    - `setTocUrl` → `setPrefix()`
    - `setTocDelimiter()` → `setDelimiter()`
    - `setTocLowercase()` → `setLowercase()`
    - `setTocReplacements()` → `setReplacements()`
    - `setTocTransliterate()` → `setTransliterate()`
    - `setTocUrlencode()` → `setUrlencode()`
- Default `transliterate` is now **false** (was **true**)
- TOC list items no longer include `toc-level-*` CSS classes
- Options moved from mutable array → dedicated typed properties
- Anchor generation rewritten for better Unicode handling and duplicate detection
- Parent constructor calls are now reflection-based
- TOC tag hashing now uses an instance-level SHA-1 salt
- Replacement handling now supports both plain strings and regex patterns

### Fixed
- Unsafe aliasing when Parsedown / ParsedownExtra is missing
- Handling of empty delimiter, TOC tag, and TOC ID values
- Regex replacement edge cases
- Empty anchor IDs (now fallback to `section`)
- Control characters in custom heading IDs
- Duplicate handling for custom and reserved IDs
- TOC link generation when using prefix:
    - Fixed incorrect `url` prefixing of full `href`
    - Links now correctly use `#id`
    - `prefix` now applies only to anchor IDs (not URLs)

### Removed
- Removed `limit` option
